### PR TITLE
fix: preserve indentation in stripIndents

### DIFF
--- a/app/utils/stripIndent.spec.ts
+++ b/app/utils/stripIndent.spec.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { stripIndents } from './stripIndent';
+
+describe('stripIndents', () => {
+  it('preserves relative indentation', () => {
+    const input = `\n  line1\n    line2\n`;
+    expect(stripIndents(input)).toBe('line1\n  line2');
+  });
+
+  it('works with template strings', () => {
+    const result = stripIndents`\n    line1\n      line2\n    `;
+    expect(result).toBe('line1\n  line2');
+  });
+});

--- a/app/utils/stripIndent.ts
+++ b/app/utils/stripIndent.ts
@@ -14,10 +14,27 @@ export function stripIndents(arg0: string | TemplateStringsArray, ...values: any
 }
 
 function _stripIndents(value: string) {
-  return value
-    .split('\n')
-    .map((line) => line.trim())
-    .join('\n')
-    .trimStart()
-    .replace(/[\r\n]$/, '');
+  // remove a leading newline that is common when using template strings
+  const lines = value.replace(/^\n/, '').split('\n');
+
+  // determine the smallest indentation level of all non-empty lines
+  let indent = Infinity;
+
+  for (const line of lines) {
+    if (!line.trim()) {
+      continue;
+    }
+
+    const currentIndent = line.match(/^\s*/)?.[0].length ?? 0;
+    if (currentIndent < indent) {
+      indent = currentIndent;
+    }
+  }
+
+  if (!Number.isFinite(indent)) {
+    indent = 0;
+  }
+
+  // slice the common indentation from each line and remove trailing newlines
+  return lines.map((line) => line.slice(indent)).join('\n').replace(/[\r\n]+$/, '');
 }


### PR DESCRIPTION
## Summary
- fix stripIndents to keep relative indentation instead of trimming each line
- add tests for stripIndents

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688b8244a1a0832d865a0d90f1a3f275